### PR TITLE
Branch CLI options to "build and exit" or "do not build and deploy"

### DIFF
--- a/README.md
+++ b/README.md
@@ -21,7 +21,7 @@ The first thing to edit is the config file. (almost) All your user settings are 
 	"_comment": "This is an overall local user config file for fugitive server deployment.",
     "droplet": {
     	"name": "fugitive-droplet",
-        "sizeslug": "s-4vcpu-8gb",
+        "sizeslug": "s-3vcpu-1gb",
         "imageslug": "docker-18-04",
         "region": "sfo2",
         "tag": "automated",
@@ -29,8 +29,10 @@ The first thing to edit is the config file. (almost) All your user settings are 
     },
     "remoteusername": "root",
     "sshprivatekey": "/Users/batman/.ssh/id_rsa_digitalocean",
-    "dockercontext": "/Users/batman/dev/Fugitive3D/extras/deploy/container",
-    "zipfilename": "fugitive-docker-ctx.zip"
+    "f3d_repo_root": "/Users/batman/dev/Fugitive3D",
+    "zipfilename": "fugitive-crap.zip",
+    "godot_linux_server_url": "https://downloads.tuxfamily.org/godotengine/3.2.1/Godot_v3.2.1-stable_linux_server.64.zip",
+    "godot_binary_path": "/Applications/Godot.app/Contents/MacOS/Godot"
 }
 ``` 
 
@@ -52,9 +54,11 @@ This section allows settings for the droplet being provisioned.
 The settings at the root level here describe some details of your local workspace.
 
 * remoteusername - This is the user account on the droplet. Use the root default for now.
-* sshprivatekey - This is an absolute path to your ssh _private key file_ on your local filesystem. This is the private key corresponding with the public one you uploaded to DO already.
-* dockercontext - This is the absolute path to the Fugitive3D repository `extras/deploy/container` directory on your local filesystem.
+* sshprivatekey - This is an absolute path to your ssh _private key file_ on your local filesystem. This is the private key corresponding with the public one you uploaded to DO already. It cannot be protected with a passphrase to be used with this script.
+* f3d_repo_root - This is the absolute path to the Fugitive3D repository on your local filesystem.
 * zipfilename - This is just a temporary name so you can leave it default. This deploy script will create this file wherever it is run. The file can be safely deleted locally after you spin up a droplet.
+* godot_linux_server_url - This is a URL the droplet is going to download the linux godot server binary from.
+* godot_binary_path - This is the absolute path on your local filesystem to godot. Used for building on the CLI.
 
 **Environment Variables**
 

--- a/config.json
+++ b/config.json
@@ -2,7 +2,7 @@
 	"_comment": "This is an overall local user config file for fugitive server deployment.",
     "droplet": {
     	"name": "fugitive-droplet",
-        "sizeslug": "s-4vcpu-8gb",
+        "sizeslug": "s-3vcpu-1gb",
         "imageslug": "docker-18-04",
         "region": "sfo2",
         "tag": "automated",
@@ -10,6 +10,8 @@
     },
     "remoteusername": "root",
     "sshprivatekey": "/Users/batman/.ssh/id_rsa_digitalocean",
-    "dockercontext": "/Users/batman/dev/Fugitive3D/extras/deploy/container",
-    "zipfilename": "fugitive-docker-ctx.zip"
+    "f3d_repo_root": "/Users/batman/dev/Fugitive3D",
+    "zipfilename": "fugitive-crap.zip",
+    "godot_linux_server_url": "https://downloads.tuxfamily.org/godotengine/3.2.1/Godot_v3.2.1-stable_linux_server.64.zip",
+    "godot_binary_path": "/Applications/Godot.app/Contents/MacOS/Godot"
 }

--- a/deploy.go
+++ b/deploy.go
@@ -8,6 +8,7 @@ import (
 	"flag"
 	"io"
 	"os"
+	"os/exec"
 	"path/filepath"
 	"time"
 
@@ -31,29 +32,38 @@ type Config struct {
 		Tag    string `json:"tag"`
 		SSHKey int    `json:"sshkeyid"`
 	} `json:"droplet"`
-	Remoteuser    string `json:"remoteusername"`
-	SSHPrivKey    string `json:"sshprivatekey"`
-	DockerContext string `json:"dockercontext"`
-	ZipFileName   string `json:"zipfilename"`
+	Remoteuser      string `json:"remoteusername"`
+	SSHPrivKey      string `json:"sshprivatekey"`
+	F3DRepoRoot     string `json:"f3d_repo_root"`
+	ZipFileName     string `json:"zipfilename"`
+	GodotBinaryPath string `json:"godot_binary_path"`
+	GodotServerUrl  string `json:"godot_linux_server_url"`
 }
 
+// relative to the F3DRepoRoot
+const DOCKERCONTEXT = "extras/deploy/container"
+
+// Parse config.json off the disk and return a Config struct.
 func RenderConfig(file string) Config {
 	var parsed Config
 	cfgFile, err := os.Open(file)
 	defer cfgFile.Close()
 	if err != nil {
-		fmt.Println(err)
+		log.Println(err)
 		log.Fatal("Error loading your configuration file!")
 	}
 	parser := json.NewDecoder(cfgFile)
 	parser.Decode(&parsed)
 
 	// These need to be absolute when used
-	if !filepath.IsAbs(parsed.DockerContext) {
-		parsed.DockerContext, _ = filepath.Abs(parsed.DockerContext)
+	if !filepath.IsAbs(parsed.GodotBinaryPath) {
+		parsed.GodotBinaryPath, _ = filepath.Abs(parsed.GodotBinaryPath)
 	}
 	if !filepath.IsAbs(parsed.SSHPrivKey) {
 		parsed.SSHPrivKey, _ = filepath.Abs(parsed.SSHPrivKey)
+	}
+	if !filepath.IsAbs(parsed.F3DRepoRoot) {
+		parsed.F3DRepoRoot, _ = filepath.Abs(parsed.F3DRepoRoot)
 	}
 
 	return parsed
@@ -61,7 +71,7 @@ func RenderConfig(file string) Config {
 
 // Reduce droplet definition down to providing a couple parameters.
 // SSH key here is an integer ID which DO gives to your public key after you upload it.
-func NewDroplet(c Config) *godo.DropletCreateRequest {
+func newDroplet(c Config) *godo.DropletCreateRequest {
 	return &godo.DropletCreateRequest{
 		Name:   c.Droplet.Name,
 		Region: c.Droplet.Region,
@@ -97,7 +107,7 @@ func publicKey(path string) ssh.AuthMethod {
 }
 
 // This is just an SCP over to the remote host using our established creds in &config.
-func runFileCopy(config ssh.ClientConfig, host string, localfile string, remotefile string) {
+func runFileCopy(config ssh.ClientConfig, host, localfile, remotefile string) {
 
 	addr := fmt.Sprintf("%s:22", host)
 	client, err := ssh.Dial("tcp", addr, &config)
@@ -106,7 +116,7 @@ func runFileCopy(config ssh.ClientConfig, host string, localfile string, remotef
 	}
 	defer client.Close()
 
-	fmt.Println("We are connected for SCP.")
+	log.Println("We are connected for SCP.")
 	pktsize := 1 << 15
 
 	c, err := sftp.NewClient(client, sftp.MaxPacket(pktsize))
@@ -122,8 +132,8 @@ func runFileCopy(config ssh.ClientConfig, host string, localfile string, remotef
 	}
 	defer w.Close()
 
-	fmt.Println("Remote file:", remotefile)
-	fmt.Println("Local file:", localfile)
+	log.Printf("Remote file:", remotefile)
+	log.Printf("Local file:", localfile)
 	// local end
 	f, err := os.Open(localfile)
 	if err != nil {
@@ -154,23 +164,23 @@ func runFileCopy(config ssh.ClientConfig, host string, localfile string, remotef
 	log.Printf("wrote %v bytes in %s", size, time.Since(t1))
 }
 
-// Run a single command on a remote system over SSH. STDOUT is returned in a string.
-func runSSHCmd(config ssh.ClientConfig, host string, command string) (string, error) {
+// Run a single command on a remote system over SSH. STDOUT is returned in a string, along with err.
+func runSSHCmd(config ssh.ClientConfig, host, command string) (string, error) {
 	var output string
 	var err error
 	target := fmt.Sprintf("%s:22", host)
 	client, err := ssh.Dial("tcp", target, &config)
-	
+
 	if err != nil {
-		fmt.Printf("Failed to dial: %s", err)
+		log.Printf("Failed to dial: %s", err)
 		return output, err
 	}
-	
+
 	// Each client connection can support multiple interactive sessions,
 	// represented by a Session.
 	session, err := client.NewSession()
 	if err != nil {
-		fmt.Printf("Failed to create session:: %s", err)
+		log.Printf("Failed to create session:: %s", err)
 		return output, err
 	}
 	defer session.Close()
@@ -178,7 +188,7 @@ func runSSHCmd(config ssh.ClientConfig, host string, command string) (string, er
 	var b bytes.Buffer
 	session.Stdout = &b
 	if err := session.Run(command); err != nil {
-		fmt.Printf("Failed to run command '%s': %s", command, err)
+		log.Printf("Failed to run command '%s': %s", command, err)
 		return output, err
 	}
 	output = b.String()
@@ -186,7 +196,7 @@ func runSSHCmd(config ssh.ClientConfig, host string, command string) (string, er
 	return output, err
 }
 
-func AddFileToZip(zipWriter *zip.Writer, filename string) error {
+func addFileToZip(zipWriter *zip.Writer, filename string) error {
 
 	fileToZip, err := os.Open(filename)
 	if err != nil {
@@ -218,9 +228,7 @@ func AddFileToZip(zipWriter *zip.Writer, filename string) error {
 
 // Zip the entire docker context (directory) so we can copy it to the remote end.
 func createDockerZIP(config Config, ch chan<- string) {
-
-	// create a new local file c.zipfilename
-	// TODO: control the path of this file.
+	// This is the temporary zip file, doesn't matter where it's placed locally.
 	zipAbsPath, _ := filepath.Abs(config.ZipFileName)
 
 	newZipFile, err := os.Create(config.ZipFileName)
@@ -233,7 +241,7 @@ func createDockerZIP(config Config, ch chan<- string) {
 	defer zipWriter.Close()
 
 	// grab all the files in the repo's docker context.
-	files, err := ioutil.ReadDir(config.DockerContext)
+	files, err := ioutil.ReadDir(filepath.Join(config.F3DRepoRoot, DOCKERCONTEXT))
 	if err != nil {
 		log.Fatal(err)
 	}
@@ -241,27 +249,28 @@ func createDockerZIP(config Config, ch chan<- string) {
 	// remove any directories we found
 	justFiles := make([]os.FileInfo, 0, len(files))
 
-	fmt.Println("Files to be included in the docker context:")
+	log.Println("Files to be included in the docker context:")
 	for _, f := range files {
 		// Don't allow recursion into directories for now.
 		if f.IsDir() {
-			fmt.Printf("Ignoring directory: %s\n", f.Name())
+			log.Printf("Ignoring directory: %s\n", f.Name())
 			continue
 		}
 		justFiles = append(justFiles, f)
-		fmt.Printf("%-11s%-12d%-2s\n", f.Mode(), f.Size(), f.Name())
+		log.Printf("%-11s%-12d%-2s\n", f.Mode(), f.Size(), f.Name())
 	}
 
 	// Add files to zip
-	fmt.Println("smooshing files together...")
+	log.Println("smooshing files together...")
 	for _, file := range justFiles {
-		abspath := filepath.Join(config.DockerContext, file.Name())
-		fmt.Printf("File added to archive: %s\n", abspath)
-		if err = AddFileToZip(zipWriter, abspath); err != nil {
-			fmt.Println(err)
+		abspath := filepath.Join(config.F3DRepoRoot, DOCKERCONTEXT, file.Name())
+		log.Printf("File added to archive: %s\n", abspath)
+		if err = addFileToZip(zipWriter, abspath); err != nil {
+			log.Println(err)
 			log.Fatal(err)
 		}
 	}
+	//TODO: Remove the local copy of this zip in a cleanup step.
 	ch <- zipAbsPath
 }
 
@@ -275,20 +284,30 @@ func grabContext(token string) (context.Context, *godo.Client) {
 	if err != nil {
 		log.Fatal(err)
 	}
-	return ctx, client
-}
-
-func provisionDroplet(config Config, ctx context.Context, client godo.Client, req *godo.DropletCreateRequest, ch chan<- godo.Droplet) {
-	// Create a droplet and poll until the public IP is known, returning it on a channel.
-	// Then poll for linux to be up and ready.
-	fmt.Println("Droplet being created with parameters:", req)
-	droplet, _, _ := client.Droplets.Create(ctx, req)
-
-	fmt.Printf("Droplet created with ID:%d\n", droplet.ID)
 
 	opt := &godo.ListOptions{
 		Page:    1,
-		PerPage: 10,
+		PerPage: 50,
+	}
+	keys, _, _ := client.Keys.List(ctx, opt)
+	log.Printf("SSH keys on your account: %d\n", len(keys))
+	for _, v := range keys {
+		log.Printf("ID: %d, Fingerprint:%s\n", v.ID, v.Fingerprint)
+	}
+	return ctx, client
+}
+
+// Create a droplet and poll until the public IP is known, returning it on a channel.
+// Then poll for linux to be up and ready.
+func provisionDroplet(config Config, ctx context.Context, client godo.Client, req *godo.DropletCreateRequest, ch chan<- godo.Droplet) {
+	log.Println("Droplet being created with parameters:", req)
+	droplet, _, _ := client.Droplets.Create(ctx, req)
+
+	log.Printf("Droplet created with ID:%d\n", droplet.ID)
+
+	opt := &godo.ListOptions{
+		Page:    1,
+		PerPage: 20,
 	}
 
 	// Poll the created droplet for the IP address given to it.
@@ -310,15 +329,31 @@ func provisionDroplet(config Config, ctx context.Context, client godo.Client, re
 	}
 }
 
+// Attempt to ssh to the target and run 'uptime'. Return true if it doesn't indicate an error.
 func isDropletUp(config ssh.ClientConfig, host string) bool {
-	// at this point, we need to poll to see if we can run userland commands
-	// so we can start copying stuff over
-	fmt.Println("Attempting to see if the droplet is reachable...")
+	log.Println("Attempting to see if the droplet is reachable...")
 	_, err := runSSHCmd(config, host, "uptime")
 	if err != nil {
 		return false
 	}
 	return true
+}
+
+func buildServerLocally(config Config) {
+	// Location of the .pck file is relative to the repo root.
+	// It's a showstopper if this cannot build the .pck
+	log.Println("Local server build is being kicked off, output will be shown below when finished.")
+	cmd := exec.Command(config.GodotBinaryPath,
+		"--path",
+		config.F3DRepoRoot,
+		"--export",
+		"Server - Linux",
+		filepath.Join(config.F3DRepoRoot, DOCKERCONTEXT, "data.pck"))
+	stdoutStderr, err := cmd.CombinedOutput()
+	if err != nil {
+		log.Fatal(string(stdoutStderr))
+	}
+	log.Println(string(stdoutStderr), err)
 }
 
 func main() {
@@ -327,13 +362,32 @@ func main() {
 	// - The linux system installed on said droplet
 	// - The applications running on the droplet. In this case, Fugitive related applcations.
 
+	var build bool
+	var now bool
 	var configlocation string
-	var destroyDroplet bool
 
+	flag.BoolVar(&build, "build", false, "Build the linux server, move it into the docker context, and exit.")
+	flag.BoolVar(&now, "now", false, "Run an entire deployment to a new droplet.")
 	flag.StringVar(&configlocation, "c", "config.json", "path to deployment config JSON file")
-	flag.BoolVar(&destroyDroplet, "d", false, "Destroy all droplets with tag 'automated'")
+	flag.Parse()
+
+	if len(os.Args) < 2 {
+		flag.PrintDefaults()
+	}
 
 	deployConfig := RenderConfig(configlocation)
+
+	// Just build the linux server pck locally, then bail.
+	if build {
+		buildServerLocally(deployConfig)
+		return
+	}
+
+	// This exits. It prevents accidental deployments. "-now" is an "are you sure?"
+	if !now {
+		return
+	}
+
 	sshConfig := ssh.ClientConfig{
 		User: deployConfig.Remoteuser,
 		Auth: []ssh.AuthMethod{
@@ -343,12 +397,16 @@ func main() {
 		HostKeyCallback: ssh.InsecureIgnoreHostKey(),
 	}
 
-	dropletChan := make(chan godo.Droplet, 1)
-	zipChan := make(chan string, 1)
-
 	ctx, client := grabContext(os.Getenv("FUGITIVE_DO_TOKEN"))
 
-	createRequest := NewDroplet(deployConfig)
+	// These three cases are:
+	// A set of API calls to DO to spin up a droplet
+	// A command to zip up all local files needed to build the docker image
+	// A timeout of 60 seconds for both channels
+	dropletChan := make(chan godo.Droplet, 1)
+	zipChan := make(chan string, 1)
+	createRequest := newDroplet(deployConfig)
+
 	go provisionDroplet(deployConfig, ctx, *client, createRequest, dropletChan)
 	go createDockerZIP(deployConfig, zipChan)
 
@@ -358,66 +416,71 @@ func main() {
 		select {
 		case dropletData := <-dropletChan:
 			// droplet data (with reachable IP), straight out of the DO API reply
-			fmt.Println("droplet finished provisioning")
-			fmt.Println(dropletData)
+			log.Println("droplet finished provisioning")
+			log.Println(dropletData)
 			publicIP = dropletData.Networks.V4[0].IPAddress
-			fmt.Printf("Droplet public IP:%s\n", publicIP)
+			log.Printf("Droplet public IP:%s\n", publicIP)
 		case zipComplete := <-zipChan:
-			// local tar file created, ready to copy.
-			fmt.Println(zipComplete)
+			// local zip file created, ready to copy.
+			log.Println(zipComplete)
 			zipFile = zipComplete
 		case <-time.After(60 * time.Second):
 			// This shouldn't take longer than a minute.
-			fmt.Println("timeout reached when provisioning droplet and/or zipping docker context.")
+			log.Println("timeout reached when provisioning droplet and/or zipping docker context.")
 		}
 	}
 
+	// We can't do anything with the droplet until it's reachable via ssh.
 	reachable := false
 	retryCount := 12
 	retryInterval := 10 * time.Second
-	fmt.Println("Attempting to see if the droplet is reachable...")
+	log.Println("Attempting to see if the droplet is reachable...")
 	for i := 0; i < retryCount; i++ {
 		response, err := runSSHCmd(sshConfig, publicIP, "uptime")
 		if err != nil {
-			reachable = false
 			time.Sleep(retryInterval)
-			fmt.Println("Still trying...")
+			log.Println("Still trying...")
 		} else {
-			fmt.Printf("Server uptime: %s", response)
+			log.Printf("Server uptime: %s", response)
 			reachable = true
 			break
-		}	
+		}
 	}
 
 	if reachable {
 		remotefile := fmt.Sprintf("/root/%s", deployConfig.ZipFileName)
 		runFileCopy(sshConfig, publicIP, zipFile, remotefile)
 	} else {
-		log.Fatal("Droplet wasn't reachable after %d attempts.", retryCount)
+		l := fmt.Sprintf("Droplet wasn't reachable after %d attempts.", retryCount)
+		log.Fatal(l)
 	}
 
 	// oh god....where are we...what is the meaning of this all?
 
-	// This all assumes we land in our homedir, so /root.
-	unzipcmd := fmt.Sprintf("unzip %s", deployConfig.ZipFileName)
+	// This all assumes we land in our homedir on the remote end, so /root.
 	prepCommands := []string{
 		"ufw allow 31000/tcp",
 		"ufw allow 31000/udp",
 		"apt install unzip",
-		unzipcmd,
+		fmt.Sprintf("unzip %s", deployConfig.ZipFileName),
+		fmt.Sprintf("curl %s -o linux.zip", deployConfig.GodotServerUrl),
+		fmt.Sprintf("unzip linux.zip"),
 		"docker build -t fugitive-server .",
 		"docker run -d --name fugitive-server --net=host fugitive-server",
+		"docker ps -a",
+		"docker logs fugitive-server",
 	}
 
 	for _, cmd := range prepCommands {
-		fmt.Printf("Executing remote command: '%s'", cmd)
+		log.Printf("Executing remote command: '%s'", cmd)
 		output, _ := runSSHCmd(sshConfig, publicIP, cmd)
-		fmt.Println(output)
+		log.Println(output)
 	}
 
-	fmt.Println("Deployment complete!")
+	// log.Printf("ID of droplet created in this run: %d", )
+	log.Println("Deployment complete!")
 	// ssh command, just in case you want to ssh in directly on the command line.
-	fmt.Printf("\nssh -i %s %s@%s\n", deployConfig.SSHPrivKey, deployConfig.Remoteuser, publicIP)
+	log.Printf("\nssh -i %s %s@%s\n", deployConfig.SSHPrivKey, deployConfig.Remoteuser, publicIP)
 
 	// uncomment to delete the droplet.
 	// client.Droplets.DeleteByTag(ctx, deployConfig.Droplet.Tag)


### PR DESCRIPTION
Having the options laid out like this does two things. First, it gives you a tool to build quickly on the command line and place the built artifacts into the docker context in the F3D repo. Second, it gives you another option to not build and instead zip up and push whatever you currently have sitting in the F3D repo. So the natural steps would be to pull down latest, do a build step, inspect the built artifact/any erros, then do a deploy -now.

This adds all print statements to log.

This adds a small print output showing you what SSH key IDs and fingerprints you already have on your account.

Note that the config file changed around a bit.